### PR TITLE
Added support for operations that do not require authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "ISC",
   "dependencies": {
     "apollo-server-express": "^2.3.1",
+    "core-js": "^3.2.1",
     "cors": "^2.8.5",
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
@@ -34,7 +35,12 @@
     "@babel/preset-env": "^7.2.3",
     "@types/cors": "^2.8.6",
     "babel-plugin-root-import": "^6.1.0",
+    "eslint": "^6.3.0",
     "graphql-resolvers": "^0.3.3",
-    "nodemon": "^1.18.9"
+    "jsonwebtoken": "^8.5.1",
+    "nodemon": "^1.18.9",
+    "passport": "^0.4.0",
+    "passport-jwt": "^4.0.0",
+    "pg": "^7.12.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/preset-env": "^7.2.3",
     "@types/cors": "^2.8.6",
     "babel-plugin-root-import": "^6.1.0",
+    "graphql-resolvers": "^0.3.3",
     "nodemon": "^1.18.9"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,10 @@ app.use(cors({
 }))
 
 app.use(passportMiddleWare.initialize())
-app.use(passportMiddleWare.authenticate('jwt', { session: false }), (req, res, next) => {
-  server.context({ req })
+app.use((req, res, next) => passportMiddleWare.authenticate('jwt', { session: false }, (_, user) => {
+  req.user = user
   next()
-})
+})(req, res, next))
 
 server.applyMiddleware({ app })
 

--- a/src/schema/requireAuthenticated/index.js
+++ b/src/schema/requireAuthenticated/index.js
@@ -1,0 +1,8 @@
+import { skip } from 'graphql-resolvers'
+
+const requireAuthenticated = (root, args, context, info) =>
+  context.currentUser
+    ? skip
+    : new Error('Not authenticated')
+
+export default requireAuthenticated

--- a/src/schema/requireAuthenticated/index.js
+++ b/src/schema/requireAuthenticated/index.js
@@ -1,8 +1,9 @@
 import { skip } from 'graphql-resolvers'
 
-const requireAuthenticated = (root, args, context, info) =>
+const requireAuthenticated = (root, args, context, info) => (
   context.currentUser
     ? skip
     : new Error('Not authenticated')
+)
 
 export default requireAuthenticated

--- a/src/schema/resolvers/user.js
+++ b/src/schema/resolvers/user.js
@@ -1,4 +1,8 @@
+import { combineResolvers } from 'graphql-resolvers'
 import models from '~/src/models'
+import requireAuthenticated from '../requireAuthenticated'
+
+const currentUser = (root, args, context, info) => context.currentUser
 
 const resolvers = {
   Query: {
@@ -6,7 +10,7 @@ const resolvers = {
 
     user: (_, username) => models.user.findOne({ where: username }),
 
-    currentUser: (parent, args, context) => context.currentUser
+    currentUser: combineResolvers(requireAuthenticated, currentUser)
   },
 
   Mutation: {


### PR DESCRIPTION
- Passport sets the user either to undefined or to a real user according to the authentication process. Later, a graphql resolver checks if there is a user in the context, allowing or forbiding the query/mutation.

